### PR TITLE
修复初始化暗号无法正确匹配问题

### DIFF
--- a/（改）网盘直链下载助手.user.js
+++ b/（改）网盘直链下载助手.user.js
@@ -641,7 +641,7 @@
                 }, 5000);
                 return;
             };
-            if (pan.num === $('#init').val()) {
+            if (pan.num.substr(0, pan.num.length - 1) === $('#init').val()) {
                 console.log("暗号正确")
                 message.success(pan.init[2]);
                 setTimeout(() => {


### PR DESCRIPTION
修复初始化暗号无法正确匹配问题
问题分析：
[https://api.youxiaohou.com/config/ali?ver=1.0.5.4&a=Hmjz100、油小猴](https://api.youxiaohou.com/config/ali?ver=1.0.5.4&a=Hmjz100、油小猴)
返回的数据解码后可以看见num字段多了一个​（\u2006）,该字符一般情况下不可见，因此无法正常匹配，应该是服务端出现了问题，目前通过删除最后一个字符解决
<img width="115" alt="image" src="https://user-images.githubusercontent.com/99261160/227994268-1f11a22c-ec83-4943-803b-e581ec623cf7.png">
